### PR TITLE
Fix filenames overflowing in the queue list

### DIFF
--- a/src/electron/app/css/page_index.css
+++ b/src/electron/app/css/page_index.css
@@ -209,6 +209,10 @@
 
     text-align: left;
     text-overflow: ellipsis;
+
+    max-width: 90%;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 #queue-list .download .status {

--- a/src/electron/app/js/index.js
+++ b/src/electron/app/js/index.js
@@ -220,7 +220,7 @@ function setupIPCListeners() {
 
         $('#download-' + arg.videoid).addClass('active')
         $('#download-' + arg.videoid + ' .status').html('Starting download..')
-        $('#download-' + arg.videoid + ' .filename').html(arg.filename)
+        $('#download-' + arg.videoid + ' .filename').attr("title", arg.filename).html(arg.filename)
         $('#download-' + arg.videoid + ' .cancel').remove()
     })
 


### PR DESCRIPTION
Long filenames are not properly contained inside the div. This fixes the
problem and also adds the "title" attribute to the div so we can see the
entire filename by hovering over it.

Before:

![before](https://user-images.githubusercontent.com/46511875/51957111-76677580-2431-11e9-9583-4c6181d27ed9.png)


After:

![after](https://user-images.githubusercontent.com/46511875/51957117-78c9cf80-2431-11e9-9e49-b70de40dc334.png)
