### PR TITLE
DataManager improvements

### DIFF
--- a/src/electron/app/js/index.js
+++ b/src/electron/app/js/index.js
@@ -299,7 +299,7 @@ function showMainMenu() {
                     },
                     {
                         label: 'Discord Chat Rooms for Support',
-                        click: () => shell.openExternal('https://discord.gg/vKwR3WB')
+                        click: () => shell.openExternal('https://discord.gg/A5p2aF4')
                     }
                 ]
             },


### PR DESCRIPTION
**I've done my own tests on this code and it worked without any issues, but it's always good to have some other people check it too, so please take your time whilst analysing this PR.**

I've included two changes to the DataManager module. The first one is an improvement of the bookmarks migration code:

The previous migration code worked by iterating twice over the bookmarks list; and to determine whether a bookmark entry was using the old format, it would check if **the first bookmark only** was missing the `lamd` object, which led to #63 being not properly fixed, since other bookmark entries might not have the `lamd` object as well.

Mine checks and fixes all bookmarks using one iteration only, and also sets `lamd.monitor` based on the original value of `lamd.monitored`, instead of directly setting it to `false`, like the previous code. I've created a dummy `bookmark.json` file so you can test the conversion yourself if you wish (I already did it myself); it has 4 entries in it:

[bookmarks-dummy.zip](https://github.com/thecoder75/liveme-pro-tools/files/2815090/bookmarks-dummy.zip)

* Entry 1: Missing the `lamd` object.
* Entry 2: Has the `lamd` object, but still uses `monitored: false` instead of `monitor: false`.
* Entry 3: Same as Entry 2, but this one has `monitored: true`.
* Entry 4: This one was already converted to the new format, so it shouldn't be modified.

---

The second commit is a bit more extensive, but it's actually fairly simple:

Based on recent events of people having their bookmarks / watched replays file being removed, I thought of adding some logic to avoid (or at least decrease) such occurrences. Even if a JSON file is not
parseable, it doesn't give us the right to overwrite it, as the user might have manually edited them to do some testing and _might_ have messed up the syntax. I'm definitely not talking about me :)

Anyway, it works by simply catching the exception thrown by `JSON.parse()` and then it tells the user the program is unable to continue because some JSON file does not have a proper syntax.

Then it gives the user three options:

* Ask for help in our **Discord** group
* **Reset** the JSON file (with a big-ass warning)
* **Close** the dialog

Here's how these dialogues look on Windows/Linux (no macOS screenshots, sorry):

<details>
 <summary>Windows 10</summary>

![downloaded-1](https://user-images.githubusercontent.com/46511875/52021676-31991880-24dd-11e9-9f6f-14c20a0afecf.PNG)

![downloaded-2](https://user-images.githubusercontent.com/46511875/52021677-31991880-24dd-11e9-972c-ee34ed5ab686.PNG)

![downloaded-3](https://user-images.githubusercontent.com/46511875/52021679-3231af00-24dd-11e9-8d53-8b06111bb078.PNG)

</details>

<details>
 <summary>Linux</summary>

![downloaded-linux-1](https://user-images.githubusercontent.com/46511875/52022028-55109300-24de-11e9-9bdd-4914280efc44.png)

![downloaded-linux-2](https://user-images.githubusercontent.com/46511875/52022029-55109300-24de-11e9-8805-171728805845.png)

![downloaded-linux-3](https://user-images.githubusercontent.com/46511875/52022030-55109300-24de-11e9-8aea-a74099151d6a.png)


</details>
<br>

Briefly explaining how they work:

The **Discord** button will simply open our Discord group URL in their default browser.

The **Reset** button will open a new dialog asking for user confirmation. If the user clicks the **Yes** button, then the JSON file shall be overwritten by an empty array -> `[]`.

If the user clicks the **No** button, it will go back to the previous dialog.

And finally, the **Close** button will close the dialog and terminate theprogram without overwriting anything.