### PR TITLE
Choose the proper video source when downloading or watching videos

### DIFF
--- a/src/electron/app/css/player.css
+++ b/src/electron/app/css/player.css
@@ -6,3 +6,13 @@
 @import url(./header.css);
 @import url(./mainarea.css);
 @import url(./footer.css);
+
+.mid-container {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.player-msg {
+    text-align: center;
+}

--- a/src/electron/app/js/index.js
+++ b/src/electron/app/js/index.js
@@ -768,16 +768,23 @@ function performShortIDSearch() {
 function performVideoLookup(q) {
     LiveMe.getVideoInfo(q)
         .then(video => {
-            if (video.videosource.length < 1) {
-                $('#status').html('Video not found or was deleted from the servers.')
+            if (video.videosource === '') {
+                let endedAt = new Date(LiveMe.getVideoEndDate(video))
+
+                $('#status').html('<h3>Video not found!</h3>' +
+                                  '<br><br>' +
+                                  `The live you're searching for ended <strong>${prettydate.format(endedAt)}</strong>.<br>` +
+                                  'The replay might still being generated or was deleted.' +
+                                  '<br><br>' +
+                                  'Try again later, maybe?')
                 $('overlay').hide()
                 $('main').hide()
             } else {
                 _addReplayEntry(video, true)
                 performUserLookup(video.userid)
             }
-        }).catch(() => {
-            $('#status').html('Video not found or was deleted from the servers.')
+        }).catch(reason => {
+            $('#status').html(`Something went wrong: ${reason}`)
             $('overlay').hide()
             $('main').hide()
         })

--- a/src/electron/app/js/index.js
+++ b/src/electron/app/js/index.js
@@ -1054,7 +1054,7 @@ function _addReplayEntry(replay, wasSearched) {
         vpm: vpm.toFixed(1),
         spm: spm.toFixed(1),
         inQueue,
-        source: replay.videosource || replay.hlsvideosource
+        source: LiveMe.pickProperVideoSource(replay)
     })
 
     allReplays.push(replayData)

--- a/src/electron/app/js/index.js
+++ b/src/electron/app/js/index.js
@@ -994,10 +994,9 @@ function openReplayContextMenu(vid) {
         }, {
             label: 'Copy Web URL to Clipboard',
             click: () => { copyToClipboard(`https://www.liveme.com/us/v/${vid}/index.html`) }
-        
         }, {
-            label: 'Copy Source to Clipboard (m3u8 or flv)',
-            click: () => copyToClipboard(`${replay.videosource || replay.hlsvideosource}`)
+            label: 'Copy Source to Clipboard (m3u8 URL)',
+            click: () => { copyToClipboard(replay.source) }
         }, {
             label: 'Read Comments',
             click: () => readComments(replay.vid)

--- a/src/electron/app/js/index.js
+++ b/src/electron/app/js/index.js
@@ -777,7 +777,7 @@ function performVideoLookup(q) {
 
                 $('#status').html('<h3>Video not found!</h3>' +
                                   '<br><br>' +
-                                  `The live you're searching for ended <strong>${prettydate.format(endedAt)}</strong>.<br>` +
+                                  `The live stream you're searching for ended <strong>${prettydate.format(endedAt)}</strong>.<br>` +
                                   'The replay might still being generated or was deleted.' +
                                   '<br><br>' +
                                   'Try again later, maybe?')

--- a/src/electron/app/js/index.js
+++ b/src/electron/app/js/index.js
@@ -374,7 +374,10 @@ function enterOnSearch(e) { if (e.keyCode === 13) preSearch() }
 
 function copyToClipboard(i) { clipboard.writeText(i) }
 
-function showSettings() { $('#settings').show() }
+function showSettings() { 
+    $('#status').hide()
+    $('#settings').show()
+}
 
 function hideSettings() {
     $('#settings').hide()
@@ -489,6 +492,7 @@ function copyReplayUrlListToClipboard() {
 
 
 function goHome() {
+    $('#status').hide()
     $('main').hide()
     $('#home').show()
 

--- a/src/electron/app/player.html
+++ b/src/electron/app/player.html
@@ -21,6 +21,8 @@
             ipcRenderer,
             remote
         } = require('electron'), LiveMe = remote.getGlobal('LiveMe');
+        const prettydate = require('pretty-date');
+
         var videoid = '',
             userid = '';
 
@@ -71,9 +73,26 @@
                     videoid = vid.vid;
                     userid = vid.userid;
 
+                    let properSource = LiveMe.pickProperVideoSource(vid)
+
+                    if (properSource === '') {
+                        let endedAt = new Date(LiveMe.getVideoEndDate(vid))
+
+                        $('#video').hide()
+                        $('.player-msg').html('<h3>Video not found!</h3>' +
+                                              '<br><br>' +
+                                              `This live ended <strong>${prettydate.format(endedAt)}</strong>.<br>` +
+                                              'The replay might still being generated or was deleted.' +
+                                              '<br><br>' +
+                                              'Try again later, maybe?').show()
+                        $('.mid-container').show()
+
+                        return
+                    }
+
                     var video = document.getElementById('video');
                     var hls = new Hls();
-                    hls.loadSource(vid.hlsvideosource);
+                    hls.loadSource(properSource);
                     hls.attachMedia(video);
                     hls.on(Hls.Events.MANIFEST_PARSED, function() {
                         video.play();
@@ -122,6 +141,9 @@
         </div>
     </header>
     <main class="has-small-header" style="display: block; overflow: hidden;">
+        <div class="mid-container" style="display: none">
+            <span class="player-msg"></span>
+        </div>
         <video id="video" controls></video>
     </main>
 </body>

--- a/src/electron/app/player.html
+++ b/src/electron/app/player.html
@@ -81,7 +81,7 @@
                         $('#video').hide()
                         $('.player-msg').html('<h3>Video not found!</h3>' +
                                               '<br><br>' +
-                                              `This live ended <strong>${prettydate.format(endedAt)}</strong>.<br>` +
+                                              `This live stream ended <strong>${prettydate.format(endedAt)}</strong>.<br>` +
                                               'The replay might still being generated or was deleted.' +
                                               '<br><br>' +
                                               'Try again later, maybe?').show()

--- a/src/electron/livemeapi.js
+++ b/src/electron/livemeapi.js
@@ -305,7 +305,7 @@ class LiveMe {
         })
     }
 
-    // Helper function to get the date of a live video ended.
+    // Helper function to get the date of when a live video ended.
     //
     // @returns int: Returns an UNIX timestamp in ms OR
     //               -1 if the video is still live

--- a/src/electron/livemeapi.js
+++ b/src/electron/livemeapi.js
@@ -304,6 +304,51 @@ class LiveMe {
             }
         })
     }
+
+    // Helper function to get the date of a live video ended.
+    //
+    // @returns int: Returns an UNIX timestamp in ms OR
+    //               -1 if the video is still live
+    getVideoEndDate(videoInfo) {
+        if (videoInfo.status == 0) {
+            // Video is still live
+            return -1
+        }
+        let endedAt = +videoInfo.vtime + (+videoInfo.videolength)
+
+        return endedAt * 1000
+    }
+
+    // Helper function used to pick the correct video source.
+    //
+    // @returns string: M3U8 URL of the replay/live video OR
+    //                  an empty string if the replay is being generated / was deleted
+    //
+    pickProperVideoSource(videoInfo) {
+        let properSource
+
+        // We should use `hlsvideosource` if it's a live video.
+        // We should use `videosource` if it's a replay.
+        //
+        // This ensures we're always getting the URL of a M3U8 file and never of a FLV stream.
+        //
+        // However, `videosource` will be empty if the replay is 30+ days older.
+        // That's because replays older than 30 days are marked as "Expired" in the official app
+        // and can't be watched (through the app).
+        //
+        // Since we're not the official app, we can ignore that, because the replay URL
+        // will still be available through `hlsvideosource`.
+        switch (+videoInfo.status) {
+            case 0:
+                properSource = videoInfo.hlsvideosource
+                break
+            default:
+                properSource = (videoInfo.videosource === '') ? '' : videoInfo.videosource
+                break
+        }
+        return properSource
+    }
+
 }
 
 module.exports = LiveMe


### PR DESCRIPTION
This addresses issue #84.

I've added more details in the commits' description. But basically it should never fail to download or watch a video/stream/replay (unless the video is _in fact_ unavailable, obviously).

I've also added some helpful messages. This one is while searching for a video id that _might_ had gone offline recently:

![not-found](https://user-images.githubusercontent.com/46511875/55366301-7bdb4d80-54be-11e9-9c0d-867e50a160a1.png)

This next one is exactly like the previous one, but is added to the video player window. It's triggered if the user clicked to watch a replay/livestream right after the streamer went offline. It's unlikely to happen, but a helpful message won't hurt anyway:

![player-error](https://user-images.githubusercontent.com/46511875/55366304-81389800-54be-11e9-80c2-6a7c11c62059.png)

Let me know what you think!

