### PR TITLE
Some fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
                 "Terminal": false,
                 "Name": "LiveMe Pro Tools"
             },
-            "icon": "src/electron/build/1024x1024.png",
+            "icon": "src/electron/build/",
             "publish": null
         },
         "appImage": {

--- a/src/electron/app/index.html
+++ b/src/electron/app/index.html
@@ -368,7 +368,21 @@
             <div class="section">
                 <ul>
                     <li style="padding-bottom: 5px;">
-                        <h4 class="titleColor">Video Player</h4>
+                        <h4 class="titleColor">Internal Video Player</h4>
+                    </li>
+                    <li style="padding-bottom: 20px;">
+                        The options below are only valid for the internal player.<br><br>
+                        <input type="checkbox" id="player-auto-resize" onchange="saveSettings()">
+                        <label for="player-auto-resize">Auto-resize the player's window to match the video's dimensions (after rotation).</label><br>
+                        <input type="checkbox" id="player-hide-restart-btn" onchange="saveSettings()">
+                        <label for="player-hide-restart-btn">Hide restart button.</label><br>
+                        <input type="checkbox" id="player-hide-settings-btn" onchange="saveSettings()">
+                        <label for="player-hide-settings-btn">Hide settings button.</label><br>
+                        <input type="checkbox" id="player-hide-fullscreen-btn" onchange="saveSettings()">
+                        <label for="player-hide-fullscreen-btn">Hide fullscreen button.</label><br>
+                    </li>
+                    <li style="padding-bottom: 5px;">
+                        <h4 class="titleColor">External Video Player</h4>
                     </li>
                     <li style="padding-bottom: 20px;">
                         Internal player is used by default unless you specify one in the field below.<br>

--- a/src/electron/app/js/index.js
+++ b/src/electron/app/js/index.js
@@ -1254,6 +1254,10 @@ function initSettingsPanel() {
     $('#viewmode-followers').prop('checked', appSettings.get('general.hide_zeroreplay_fans'))
     $('#viewmode-followings').prop('checked', appSettings.get('general.hide_zeroreplay_followings'))
 
+    $('#player-auto-resize').prop('checked', appSettings.get('player.resize_on_rotate'))
+    $('#player-hide-restart-btn').prop('checked', appSettings.get('player.hide_restart_button'))
+    $('#player-hide-settings-btn').prop('checked', appSettings.get('player.hide_settings_button'))
+    $('#player-hide-fullscreen-btn').prop('checked', appSettings.get('player.hide_fullscreen_button'))
     $('#playerpath').val(appSettings.get('general.playerpath'))
 
     $('#cleanup-duration').val(appSettings.get('history.viewed_maxage'))
@@ -1347,10 +1351,14 @@ function saveSettings() {
 
     appSettings.set('general.hide_zeroreplay_fans', (!!$('#viewmode-followers').is(':checked')))
     appSettings.set('general.hide_zeroreplay_followings', (!!$('#viewmode-followings').is(':checked')))
-    
+
     appSettings.set('general.hide_high_fan_count', (!!$('#hide-many-fans').is(':checked')))
     appSettings.set('general.hide_high_fan_count_value', parseInt($('#hide-many-fans-count').val()))
-            
+
+    appSettings.set('player.resize_on_rotate', $('#player-auto-resize').is(':checked'))
+    appSettings.set('player.hide_restart_button', $('#player-hide-restart-btn').is(':checked'))
+    appSettings.set('player.hide_settings_button', $('#player-hide-settings-btn').is(':checked'))
+    appSettings.set('player.hide_fullscreen_button', $('#player-hide-fullscreen-btn').is(':checked'))
     appSettings.set('general.playerpath', $('#playerpath').val())
 
     appSettings.set('history.viewed_maxage', $('#cleanup-duration').val())

--- a/src/electron/app/js/player.js
+++ b/src/electron/app/js/player.js
@@ -176,24 +176,39 @@ function setupFlv(source) {
 
 function setupShortcuts() {
     document.addEventListener('keydown', event => {
+        // Make sure we don't create conflicts with other shortcuts using the
+        // same keys, but with different modifiers, e.g. pressing "Ctrl+A" or
+        // "Alt+A" should not trigger our "A" shortcut
         switch (event.code) {
             case 'Comma':
-                if (video.paused) video.currentTime -= 0.05
+                if (!event.altKey && !event.ctrlKey) {
+                    if (video.paused) video.currentTime -= 0.05
+                }
                 break
             case 'Period':
-                if (video.paused) video.currentTime += 0.05
+                if (!event.altKey && !event.ctrlKey) {
+                    if (video.paused) video.currentTime += 0.05
+                }
                 break
             case 'KeyA':
-                video.currentTime -= 10
+                if (!event.altKey && !event.ctrlKey) {
+                    video.currentTime -= 10
+                }
                 break
             case 'KeyD':
-                video.currentTime += 10
+                if (!event.altKey && !event.ctrlKey) {
+                    video.currentTime += 10
+                }
                 break
             case 'ArrowRight':
-                if (event.altKey) videoRotate('right')
+                if (event.altKey && !event.ctrlKey) {
+                    videoRotate('right')
+                }
                 break
             case 'ArrowLeft':
-                if (event.altKey) videoRotate('left')
+                if (event.altKey && !event.ctrlKey) {
+                    videoRotate('left')
+                }
                 break
         }
     })

--- a/src/electron/datamanager.js
+++ b/src/electron/datamanager.js
@@ -50,16 +50,16 @@ function handleConfigFileError(error, filePath) {
             title: `Unable to read ${path.basename(filePath)}`,
             message: `File '${path.basename(filePath)}' appears to be corrupt!\n\n` +
                      'In order to avoid data loss, the program will abort now.\n' +
-                     'If you need help, screenshot this error and show it to someone in our Discord group:\n',
+                     'If you need help, screenshot this error and show it to someone in our Gitter group:\n',
             detail: `File: ${filePath}\n${error.name}: ${error.message}`,
-            buttons: ['Open Discord group', 'Reset file (DANGEROUS!)', 'Close'],
+            buttons: ['Open Gitter group', 'Reset file (DANGEROUS!)', 'Close'],
             cancelId: 2,
             defaultId: 0,
         })
 
         switch(btn1) {
             case 0:
-                shell.openExternal('https://discord.gg/A5p2aF4')
+                shell.openExternal('https://gitter.im/thecoderstoolbox/liveme-pro-tools')
                 break
             case 1:
                 btn2 = dialog.showMessageBox({

--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -68,7 +68,27 @@ function createWindow() {
     mainWindow.loadURL(`file://${__dirname}/app/index.html`)
     mainWindow
         .on('open', () => {})
-        .on('close', () => {
+        .on('close', (event) => {
+            let toDownload = dlQueue.running() + dlQueue.length()
+            let userChoice = 0
+
+            if (toDownload > 0) {
+                userChoice = dialog.showMessageBox(mainWindow, {
+                    type: 'question',
+                    title: 'Download is in progress',
+                    message: `You still have ${toDownload} ` +
+                             (toDownload > 1 ? 'videos' : 'video') +
+                             ' to download.\n\n' +
+                             'Exit anyway?',
+                    buttons: ['Yes', 'No'],
+                    cancelId: 1,
+                    defaultId: 1,
+                })
+            }
+            if (userChoice === 1) {
+                event.preventDefault()
+                return false
+            }
             appSettings.set('position.mainWindow', mainWindow.getPosition())
             appSettings.set('size.mainWindow', mainWindow.getSize())
 

--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -157,7 +157,8 @@ app.on('ready', () => {
             template: '%%replayid%%',
             chunkthreads: 1,
             chunks: 1,
-            ffmpegquality: 1
+            ffmpegquality: 1,
+            parallel: 3
         })
         appSettings.set('player', {
             volume: 1,
@@ -197,7 +198,8 @@ app.on('ready', () => {
             bookmarksWindow: [-1, -1]
         })
     }
-    
+    dlQueue.concurrency = +appSettings.get('downloads.parallel') || 3
+
     createWindow()
 })
 
@@ -642,7 +644,7 @@ const dlQueue = async.queue((task, done) => {
                 break
         }
     })
-}, +appSettings.get('downloads.parallel') || 3)
+})
 
 
 /**

--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -161,7 +161,11 @@ app.on('ready', () => {
         })
         appSettings.set('player', {
             volume: 1,
-            muted: false
+            muted: false,
+            resize_on_rotate: false,
+            hide_restart_button: false,
+            hide_settings_button: false,
+            hide_fullscreen_button: false
         })
     }
 

--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -671,7 +671,6 @@ ipcMain.on('watch-replay', (event, arg) => {
                         autoHideMenuBar: false,
                         disableAutoHideCursor: true,
                         titleBarStyle: 'default',
-                        fullscreen: false,
                         maximizable: false,
                         frame: false,
                         backgroundColor: '#000000',


### PR DESCRIPTION
List of fixes/changes:

* Player not entering full screen mode on macOS (#88)
* Avoid keyboard shortcuts conflicts: Pressing <kbd>Ctrl</kbd>+ <kbd>A</kbd> should not trigger the <kbd>A</kbd> shortcut.
* No auto-resizing of the video player window anymore (unless enabled in Settings).
* New options to customize the video player: [Before](https://user-images.githubusercontent.com/46511875/56333839-22d11200-616c-11e9-9860-127f0666f229.png) and [After](https://user-images.githubusercontent.com/46511875/56333851-2f556a80-616c-11e9-83fa-5b184340112b.png).
* Program icon on Linux now works again: [Before](https://user-images.githubusercontent.com/46511875/56335094-8578dc80-6171-11e9-8af4-dc9cdf8b27c6.png) and [After](https://user-images.githubusercontent.com/46511875/56335104-91fd3500-6171-11e9-90b5-987dd36c014b.png).
* Fixed a race condition that tried to read the Settings file when it hadn't been created yet, when running the program for the first time: [Error looked like this](https://user-images.githubusercontent.com/46511875/56335011-2024eb80-6171-11e9-84bb-951f8b61c144.png).
* Ask before exiting the program if we're downloading one or more videos: [Looks like this](https://user-images.githubusercontent.com/46511875/56333983-de924180-616c-11e9-9bb8-d7f9bac01f6b.png).
* Change Discord references to Gitter.

