### PR TITLE
WebPref settings missing

### DIFF
--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -713,7 +713,9 @@ ipcMain.on('watch-replay', (event, arg) => {
                     webPreferences: {
                         webSecurity: false,
                         textAreasAreResizable: false,
-                        plugins: true
+                        plugins: true,
+                        nodeIntegration: true,
+                        contextIsolation: false, 
                     }
                 })
                 require("@electron/remote/main").enable(playerWindow.webContents)


### PR DESCRIPTION
I think these got over written in the merge process. Causes replays not to work.